### PR TITLE
Optimize event recording mechanism

### DIFF
--- a/src/main/java/org/cooper/simulation/Cloudlet.java
+++ b/src/main/java/org/cooper/simulation/Cloudlet.java
@@ -13,25 +13,48 @@ public class Cloudlet {
     private double executionTime;
     private final long vmId;
 
+import org.cloudsimplus.listeners.CloudletEventInfo;
+
+public class Cloudlet {
+
+    @SerializedName("id")
+    private final long cloudsimId;
+    private double startTime;
+    private double finishTime;
+    private final long length;
+    private long finishedLength;
+    private double executionTime;
+    private final long vmId;
+
     public Cloudlet(org.cloudsimplus.cloudlets.Cloudlet cloudlet) {
         this.cloudsimId = cloudlet.getId();
         this.length = cloudlet.getLength();
         this.finishedLength = cloudlet.getFinishedLengthSoFar();
         this.executionTime = cloudlet.getTotalExecutionTime();
         this.vmId = cloudlet.getVm().getId();
+        // Assuming a listener for Cloudlet finish events exists
+        cloudlet.addOnFinishListener(this::onCloudletFinishListener);
+    }
+
+    // Listener for Cloudlet finish events
+    public void onCloudletFinishListener(CloudletEventInfo event) {
+        var finishedCloudlet = event.getCloudlet();
+        this.finishTime = finishedCloudlet.getFinishTime();
+        this.finishedLength = finishedCloudlet.getFinishedLengthSoFar();
+        this.executionTime = finishedCloudlet.getTotalExecutionTime();
     }
 
     public void record(org.cloudsimplus.cloudlets.Cloudlet cloudlet, double time) {
-        if (cloudlet.getStartTime() >= 0) {
+        if (cloudlet.getStartTime() >= 0 && this.startTime == 0) { // Record start time only once
             this.startTime = cloudlet.getStartTime();
         }
 
-        if (cloudlet.getFinishTime() > 0) {
-            this.finishTime = cloudlet.getFinishTime();
+        // Finish time is now handled by the listener.
+        // We still need to update progress periodically for running cloudlets.
+        if (cloudlet.getFinishTime() <= 0) { // If cloudlet hasn't finished
+            this.finishedLength = cloudlet.getFinishedLengthSoFar();
+            this.executionTime = cloudlet.getTotalExecutionTime();
         }
-
-        this.finishedLength = cloudlet.getFinishedLengthSoFar();
-        this.executionTime = cloudlet.getTotalExecutionTime();
     }
 
     public long getCloudsimId() {


### PR DESCRIPTION
Introduced event listeners for VM creation, Cloudlet submission, and Cloudlet completion to update simulation recording state incrementally. This reduces the overhead of the main `tick` method.

Refactored `SimulationRecording.tick`, `Host.record`, `Vm.record`, and `Cloudlet.record` methods. The `record` methods now complement event-driven updates and provide fallbacks to ensure data capture even if specific event listeners are not available or effective in the CloudSimPlus version being used.

This change aims to improve performance by processing entities reactively where possible, while maintaining robustness of data collection through periodic polling during `tick`.